### PR TITLE
[TT-17030] Migrate workflows from PAT to GitHub App token

### DIFF
--- a/.github/workflows/auto-generate-dashboard-sdks.yml
+++ b/.github/workflows/auto-generate-dashboard-sdks.yml
@@ -42,6 +42,14 @@ jobs:
       - name: Install GitHub CLI
         run: |
           sudo apt-get install gh
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+
       - name: Set TARGET_BRANCH environment variable
         id: set-target
         run: |
@@ -72,7 +80,7 @@ jobs:
 
       - name: Download The swagger file from the dashboard
         env:
-          GITHUB_TOKEN: ${{ secrets.ORG_GH_TOKEN}}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           gh api "repos/${{ secrets.FILE_PATH }}/swagger.yml?ref=${{ env.TARGET_BRANCH == 'main' && 'master' || env.TARGET_BRANCH }}" --header "Accept: application/vnd.github.v3.raw" > swagger.yml
       - name: Set up Go
@@ -100,7 +108,7 @@ jobs:
         if: ${{ env.BRANCH_EXISTS == 'true' }}
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.ORG_GH_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           commit-message: "save generated dashboard sdks for source branch ${{ env.TARGET_BRANCH }}"
           title: "Generated dashboard SDKs for ${{ env.TARGET_BRANCH }}"
           body: "This PR contains the generated dashboard SDKs."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,8 +8,15 @@ jobs:
     runs-on: ubuntu-latest
     env:
       GOPRIVATE: github.com/TykTechnologies
-      GH_ACCESS_TOKEN: ${{ secrets.ORG_GH_TOKEN }}
     steps:
+      - name: Generate GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@d72941d797fd3113feb6b93fd0dec494b13a2547  # v1
+        with:
+          app-id: ${{ secrets.PROBE_APP_ID }}
+          private-key: ${{ secrets.PROBE_APP_PRIVATE_KEY }}
+          owner: TykTechnologies
+
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -19,7 +26,7 @@ jobs:
         with:
           go-version: '1.23.2'
 
-      - run: git config --global url.https://$GH_ACCESS_TOKEN@github.com/.insteadOf https://github.com/
+      - run: git config --global url.https://${{ steps.app-token.outputs.token }}@github.com/.insteadOf https://github.com/
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:


### PR DESCRIPTION
## Summary
- Replace all `ORG_GH_TOKEN` (PAT) references with GitHub App tokens generated via `actions/create-github-app-token` in 2 workflow files
- `auto-generate-dashboard-sdks.yml`: replaces GITHUB_TOKEN env var for `gh api` calls and `peter-evans/create-pull-request` token
- `release.yml`: replaces `GH_ACCESS_TOKEN` env var used in `git config insteadOf` for private Go module access

## Files changed
- `.github/workflows/auto-generate-dashboard-sdks.yml` — 1 job, 2 token references
- `.github/workflows/release.yml` — 1 job, 1 env var + 1 insteadOf pattern

## Test plan
- [ ] Verify PROBE_APP_ID and PROBE_APP_PRIVATE_KEY secrets are available in this repo
- [ ] Trigger auto-generate-dashboard-sdks workflow and confirm it can download swagger files and create PRs
- [ ] Push a tag and confirm release workflow can access private Go modules via git config insteadOf

🤖 Generated with [Claude Code](https://claude.com/claude-code)